### PR TITLE
clover: Fix compilation error in clover::llvm::compile_to_spirv

### DIFF
--- a/src/gallium/state_trackers/clover/llvm/invocation.cpp
+++ b/src/gallium/state_trackers/clover/llvm/invocation.cpp
@@ -259,7 +259,7 @@ clover::llvm::compile_to_spirv(const std::string &source,
 
    std::stringstream ss;
    ::llvm::raw_os_ostream out(ss);
-   if (!::llvm::WriteSPIRV(mod.get(), ss, error_msg)) {
+   if (!::llvm::WriteSPIRV(mod.get(), out, error_msg)) {
       r_log += "Translation from LLVM IR to SPIR-V failed: " + error_msg + ".\n";
       throw error(CL_INVALID_VALUE);
    }


### PR DESCRIPTION
Fixes:
../../../../../src/mesa/src/gallium/state_trackers/clover/llvm/invocation.cpp:262:39: error: 
      non-const lvalue reference to type 'llvm::raw_ostream' cannot bind to a value of unrelated type
      'std::stringstream' (aka 'basic_stringstream<char>')
   if (!::llvm::WriteSPIRV(mod.get(), ss, error_msg)) {
                                      ^~
